### PR TITLE
Fix create_or_update call

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -7,6 +7,7 @@ name = "pypi"
 ipython = "*"
 pytest = "*"
 "flake8" = "*"
+mock = "*"
 
 [packages]
 watchdog = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "490fe4dc36469c85560ba81071fa6306e18a9dcf70dd478ba347a781fe55898c"
+            "sha256": "0237c6ae60ddd660ea0a02137c77af38520cf4c5c0ba46426570975b664f8538"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -44,79 +44,79 @@
         },
         "grpcio": {
             "hashes": [
-                "sha256:007a6f1d2c2eb4631f815dc413b109a0687775b8b18e33e99cb971d611f7709d",
-                "sha256:12f0d320c99f8ed8ab746e1eb9592b7c52aa133a99c25d1fc7ac3024c8db7839",
-                "sha256:15a040e9c7cd2755a082c701ce8e12842ca166ff54fdf448ce1c70ee143dc228",
-                "sha256:19bb32ddedfc8424698ee4533362c40c0fbfdd2e922a9b26557a26446a479fed",
-                "sha256:3d69bc0a49c796dffa930761949d2d099fa42dfa7a8ecbb7efa74b1cc69abae3",
-                "sha256:4cd3ba58176934ff6d2662547f0aecc9dfab9c6b6b3177087d9b710b6237b9d4",
-                "sha256:5f4992672d76dfdca0158c2fdf17631fd4ac0106fd48d9daa1d1be589f02597f",
-                "sha256:5f51019780e3dfd50fdf343357814927d3707ebaccb847d65f7626be7b069896",
-                "sha256:61b19e889c2ea6b941722a1b1226717b68bb40af80ca0d94e1f87a5bb61bd500",
-                "sha256:7e72a98bd236d76846c57ac01ab4aadc337ca4f6d451f02372f27f94e9c56c1d",
-                "sha256:800be53727f56e173bc0cd462478c5f25d56e99e7978fdb6717bcf482872caf8",
-                "sha256:8aef8f9e449a6e175a59152f49c52519f5887f3a626fac75a75d91f3cb68d89d",
-                "sha256:90bc328ca96671255d89034405e57d98abe7e4f529721eee5b78bb971ee4d53b",
-                "sha256:92f279484675abcbfc5ff12cc97df29300eecbfafa83eac4ee1a6438bd3a9c9b",
-                "sha256:94a609780c316b36631858a863268d3a17929b9cfa11ffda99e7a4c061adfe31",
-                "sha256:9d8851e18731577e0cb4aa326abd1179fb2dc18ca1af26c7b5a853706a32aa62",
-                "sha256:b22122fb0674c1e2af7dd684e71d15de27918181213afb8d31f3ab7d97da8007",
-                "sha256:b2ef358fe5bae8dab2e822fd204f2f61f61cc27e276b58fb5e0215d7a553b208",
-                "sha256:b3dff5ffe4a7f5f988fd7d6233639a4dd4e3d5d52b5cb99a7c45151ebbadc15c",
-                "sha256:b626d0461bf2e466d8c8969ba16263218214d5e4d7856710590f8b6e1fe7c14b",
-                "sha256:baacd8c51e9d0ba9de58021778da2589274db518d16639b192a32a2947202f54",
-                "sha256:bb50103ba19b4ce4259639367ce84f06a638ea42586ab82ac15e2bea4772a5c9",
-                "sha256:cb468146d0b16c56f0c5087f182e0ee18edfde18cf986feabb3f0dc5d05faefc",
-                "sha256:cc16f771c0206af2c780f4f06f684cede3546a072c8f3527b190e1db7795354d",
-                "sha256:dadaf58e000251bfbcdfe8b270d076b90886742883af9d604c0efb1f9dc8a9e8",
-                "sha256:e86e04a3434c8c59b12c016c5a509fd8a9d13e20c4b3e392f0a47e702dd7ac39",
-                "sha256:e886e6317e62a027fbb30ff3bdbf510247ed805131520225aba85821175202d8",
-                "sha256:f197515a12c98bd4e199a06fced131c1623ff6ee443754a9ca97fc98f57af4b0",
-                "sha256:f26aff4e93ea40d1e6f1f7130b6d39877f3834abb0b2aa0e66fd3073acdc009d",
-                "sha256:f27da3b44037d039e2a55c4d98d04967a3588272d964acaf95676af3389f1419",
-                "sha256:f3109009be69953dcef69ced58b2f563af8bb6f9b8947fa14a122da78e361cc1",
-                "sha256:fa9b6949f1546be56c7bd7b956a06555c1cfc110a6615b495725326f51a757b4"
+                "sha256:00e0ed7a4558b65df24aed9369880c7e247bcd48c9c71c9c40f3143ab02842a5",
+                "sha256:113d457cf87a2d642820f2a442008d714c52f9760fea2c02b22fe06aacc40531",
+                "sha256:114399097a2af15fac768dd99c32171ed33804bf127945b5cba0fb9f4380b09d",
+                "sha256:14a16eb13472cb16213dad17d4580d885824e04b93ae4323ed532168f99477a0",
+                "sha256:15a5fc23ba2e5f30758fbb8763f79a764e3de1ffcb92c2ccd46f45ffa63910d2",
+                "sha256:16cdd82a3aed9b6d3067492413bfffe61bf0f98c06f2942f887d79b8fd68898d",
+                "sha256:21901beb267bd996a094d960996bff047db7c10ad3bfa7bd4689eb0374101e63",
+                "sha256:253ae7ed8b50132ab331146ecb329d740330f9f76b6986cc36c3280eb74878c7",
+                "sha256:25f2d6120e710223195027375855a06cfc5a4f448e89b20f8f09975527297aeb",
+                "sha256:2767b87260b2256d738a496d5aaf8ce4bbeef34cdbe9c852508c09a36ff35631",
+                "sha256:2fffb227db6d95e62086563720518cd5cdbf7127675f49067f55d3c7cca019c4",
+                "sha256:3b16f12bedb3fc22db8c4a55119f460778330d0ca44cc9716d106170b4270685",
+                "sha256:3f57682b103febfd603350d2e0c91bdb5240593dd3c377ade9ab27da0540f4ad",
+                "sha256:4473f462accbfb6207174af8bbdd21c09d355a16d6a718e24810afb236ed237e",
+                "sha256:4a70e37c6bf2f81f48f739184c058c9912caf9fd85db6b8688e8916b748b02cb",
+                "sha256:529b872bddc0ad5243fa58f77dfbac1a04c9812f35a4d2033cba795e3b579411",
+                "sha256:5f54bb445a443a12123d88f3f83a715d00c0579481201e08caa931a0c38f794e",
+                "sha256:670e884e5b5c8805e30d214da790cb86487db27ed9e7ccd74f11a2bc5a27df2b",
+                "sha256:67f1dd57935abe0d090f3b5f9fbc4d7ef84a53c9cd806c7cb91a2bda9dd8f14a",
+                "sha256:6bb4acb354a0f84ca767658bf414b70dbfc88a41210456720e5ef1248354b0ad",
+                "sha256:701534465e7936524e786f9448e9ccc9a519fddb59bca744ef2abe04fd737104",
+                "sha256:7ab4fcef50ec8257a4ec5ff676001d9be466aa965df57ccf89873a263c7bb4ae",
+                "sha256:7b2f2882a909213d038f399dcf07995870e3a2f27a93ce8dbfb65db860df30be",
+                "sha256:9380f8365d9fd7fea6497615295b4e749345bdc7990655d52ad22fef0127f1d3",
+                "sha256:aa4ca8f74500d90a6b8745aef03fb765b8c1655524f695baa46320763aad5822",
+                "sha256:bf203d00fa7d7f9a67646c5468732b03330f7910fffa1bac7dcde956d27d3508",
+                "sha256:cba9f8b4910644c6664f875ba20e8ea031919118d4567fe0b77aee28d7fa32c6",
+                "sha256:d360ccb3aedec5b799c8b0d7968013b92a5a67fad00da77ff987360d59182f9f",
+                "sha256:e0b262828da4b0986ab9994ed8727655b21f1575b6b31cf2f05ba0d9ca650bae",
+                "sha256:e9caf61a789dd657404195d7bc0d3e521bf1878b43448ffe8b03bb03e27fb23d",
+                "sha256:eade750711df77696ae8361412018c0b294bb078fc0a3b51f5a77e789af692c7",
+                "sha256:f322631581149eb35f834ea0defcacf4edc8641db206f83027b9c239aa46a442"
             ],
             "index": "pypi",
-            "version": "==1.14.2"
+            "version": "==1.15.0"
         },
         "grpcio-tools": {
             "hashes": [
-                "sha256:0364fc8bdfbd9f1fb6f23d4f95c1945713a93fc24da116be0931f536c6c99817",
-                "sha256:0a059a550da9ee8d3419a03186846196e1e7802c69a7d88f1907be381b520567",
-                "sha256:134135e1eb3d9d17d9e065b0e833fc50f36f0e963c17f56f4602fd3497db968e",
-                "sha256:2a5e43ed70c5ec1ae725f3e4b155e6b30fd74d15307a535ed8d1bb52ede768e6",
-                "sha256:2ec4944e3d516963eb571b013dc1bdbe999c25ef2853f45f38b5cdab0a6412f6",
-                "sha256:32976716af1d84fd9a6f1a0663fca47cb3ef71a82dd2b5e365ac11a3d52d6876",
-                "sha256:32b36432f942e77550916863a7a8cf4aa79192390ee04b3d0049c492d4625f53",
-                "sha256:4ed5dd160acf7671e7839f990b2b4c0197a3b065eef2d44d605809a88d489f61",
-                "sha256:5fa92ad71f54da698759afa3bcf566dfa1244ea7c4f1451265bb7de993965cea",
-                "sha256:6021289c6c64b19b97f9bfd0f6b65e1bec6b03037764253f4168ba2788ff183d",
-                "sha256:60c85264e357ad552e14bd9086488fd5fd0b5ba59a316f939b758719aa3ba19f",
-                "sha256:63994614a79ee32a0df387758ddb9af399cd77ac7318c170132e65e726415cdf",
-                "sha256:63d91b706fda6c5efbec180fa34444e0f69ef65b4718920c8eebba9a8803ad39",
-                "sha256:6678d6d366b01ddecbdd04daee15affe937675f418b826b1c6ab2ed5574c262e",
-                "sha256:74fdb613397499b9fd9ccaa262946cd29e506020ae7a5d74cc48145f19aa6fb0",
-                "sha256:7650dc5dcd37d1c743f02346499017fdc344a8b9195d14d15901f1f21cc48412",
-                "sha256:854726aa28838c6ff24ab34d24b203f611430fb526a0d8a26e4fb068c4815f23",
-                "sha256:900597ba0940f918915eba925336c0d706a8f9402fbe9660d31048088b80b67f",
-                "sha256:96d8f694feda7d4f27048da30d0d5342b9f1f36983ff906d50c85aa6cde599bc",
-                "sha256:9b77e14858f712525f8743b6a6669e6c6fbb1d3c7cb81bb37e3f3df3abf22b67",
-                "sha256:9cabcd4d101f70c491e87666085e295907d52704599f957228b084c9ee117e9a",
-                "sha256:a4613fd2c178d8429b1425eb64efe7431691615add4e69dc0a312cf0cc5413a9",
-                "sha256:b3fd64a5b8c1d981f6d68a331449109633710a346051c44e0f0cca1812e2b4b0",
-                "sha256:b4b522f35a4bcc8ea9a3307e46cfdaa082ea2c547eff6b6d134487b13f6bbba2",
-                "sha256:b98e04d919ec9c1cf77391cb4c8460a8a0cff55c679ab6e67ad2eba7bb2ea0d5",
-                "sha256:b9ac6f2c3aa82c7c26252f0e691aa4dc8aaabe65d221dce4824c08eb9f76f5a7",
-                "sha256:c058bc7d7f4cb87322d0df86cc9326c6fd4880ac8f580487b37e57c9d1f50d5f",
-                "sha256:c110c3181c78c0745dcb7ff223a9ec1bc09bd5eda174480b130baae838138161",
-                "sha256:c78a9c562294796a5c4907fc7b46cd3c5c80375c3cbc50ff014cec2761d466d1",
-                "sha256:ec6689c2e09dbb79c49d6d4fee09cd4a8522d89e885fffdb104754ea154a38a0",
-                "sha256:fbb83408d15736e231b424b5e3a3433593273674484b73d2f1f61ca603a7a75f",
-                "sha256:fca00f5d61e1374407ae195da18d706a53d39b8a3f538a89b2e9d90fe2bc02cc"
+                "sha256:01fc9dcbb1a8e8f763ec143930519e5e8551a25a4d1b7706a10809c8339b0377",
+                "sha256:0346fdfd5307f9283a1fc0b8936d57a123636c66aca2f402303941a2c805f20f",
+                "sha256:0d0039e1226d037c04cb6300254f13eb87c60d88abd5a14b99c32b881e06dacd",
+                "sha256:1e57e1cc9945c5f838b3270d04634bc9076486bf064359f20c8761a98126dce2",
+                "sha256:2bf8761307f54fdf116372bc7580ee5fa899c5fafca75e0f833c8339613d77f5",
+                "sha256:3c3599a6882532801a5757955b70836d70a3da2f187937e0a6835dce5c11f05f",
+                "sha256:3cfea4815236aa7c875150cc402d168bfcb6c0884cc753d53cde3099a8920efd",
+                "sha256:4172f50c24d5b4135023b4193ce5fe6e7515dcbb91b4ee01f20459b816aee0a0",
+                "sha256:421f8815fd6173c5110e5bb2c682c29bdb694b598641379a9a773e04a907f0d8",
+                "sha256:6002e05ef8c20de23887fccb8c74b55f85544a822c06dad618ebc90c409c2d83",
+                "sha256:61a418f4ce288d44eee9acbb30fd73255083d35ca481f40954c2932f3efe621b",
+                "sha256:6678191ee6ddc0c02ae6be9d5f759a904e61866e29c2ab8df85a88798aca681f",
+                "sha256:6e71cbcfd22ff15ba89b3856e1bb390084315b27f822cc1266f73864820fae81",
+                "sha256:7329622e9ac365dd0751c337e5c99ccfec9a8b60a5cc44d58bb7e569b5ea7c81",
+                "sha256:7576d16d6c1f2946a1ea495dc57d849afd29df547fd125d4a4f213e3ee976417",
+                "sha256:9738e750aa207d4651d719c0f5e3cf1e0bf2b6b6088bf6c15fd93a9b64580b55",
+                "sha256:989f3479e69ab3a72f70065de6d000a611a25a53166711981a3e8c99671d5705",
+                "sha256:a984e5c7f456a6e65ef00899151187ff520c8f42222944ad4b85b136321ce949",
+                "sha256:a9a98c293d54de819c2cac138f48cffe78890a2abfc6cfa42985ee8897121764",
+                "sha256:aa4f8f5c6f059d5c3ae756821494821545b1ebc203c1ed12c1366fe011dc2a5c",
+                "sha256:ac5962315518b0eb271b429ff01e6da3bf36eff54aa0234502c10238164c5237",
+                "sha256:af8683a74a43d9cc76d316c90d3369072cfc0e9b2833a4a21c0d0d6082d63161",
+                "sha256:b1bba27c6cf2d967d35d7aea2be4495b8b82596dccf941237d960509c22a8c56",
+                "sha256:b8b33d1ebbd1860b116e83ca655b696c314cd34b0c2336b75a3c882d28299274",
+                "sha256:bdee353eb9ec9353d83613b35853276c72c60516b595569e2624575bf3fdbeab",
+                "sha256:ce0415c33ff47e7ac4aea9d6a283fc8fc05bebe6857e7431b584be9d253fa193",
+                "sha256:cfbb7db17980ab099aa8ca50f2c178d86af8e8b84317ff9993d291d31362a09f",
+                "sha256:d04e1d148eb27c4582c76324182771a459d82bfc3f6500303fee17775f06298d",
+                "sha256:dab46b5362775fe1f45d72ab00d85bed04c83f0ef041e4d99f5d33d07318ae28",
+                "sha256:e586f7ba57c7bf9ac7131145f16a1eececd4e063296c219c22131d4f019e8140",
+                "sha256:e71e0bf098a7c1c1d53dbabea1cc61b3a01a31994851a05721bc9fecdda21266",
+                "sha256:f61c6f6394201344754e139370adbec3ee390aa53e5d1063b64569d131f70611"
             ],
             "index": "pypi",
-            "version": "==1.14.2"
+            "version": "==1.15.0"
         },
         "idna": {
             "hashes": [
@@ -148,7 +148,6 @@
                 "sha256:ceec283da2323e2431c49de58f80e1718986b79be59c266bb0509cbf90ca5b9e",
                 "sha256:fcfc907746ec22716f05ea96b7f41597dfe1a1c088f861efb8a0d4f4196a6f10"
             ],
-            "markers": "python_version != '3.2.*' and python_version >= '2.7' and python_version != '3.1.*' and python_version != '3.3.*' and python_version != '3.0.*'",
             "version": "==3.6.1"
         },
         "pyyaml": {
@@ -184,16 +183,16 @@
         },
         "tornado": {
             "hashes": [
-                "sha256:1c0816fc32b7d31b98781bd8ebc7a9726d7dce67407dc353a2e66e697e138448",
-                "sha256:4f66a2172cb947387193ca4c2c3e19131f1c70fa8be470ddbbd9317fd0801582",
-                "sha256:5327ba1a6c694e0149e7d9126426b3704b1d9d520852a3e4aa9fc8fe989e4046",
-                "sha256:6a7e8657618268bb007646b9eae7661d0b57f13efc94faa33cd2588eae5912c9",
-                "sha256:a9b14804783a1d77c0bd6c66f7a9b1196cbddfbdf8bceb64683c5ae60bd1ec6f",
-                "sha256:c58757e37c4a3172949c99099d4d5106e4d7b63aa0617f9bb24bfbff712c7866",
-                "sha256:d8984742ce86c0855cccecd5c6f54a9f7532c983947cff06f3a0e2115b47f85c"
+                "sha256:0662d28b1ca9f67108c7e3b77afabfb9c7e87bde174fbda78186ecedc2499a9d",
+                "sha256:4e5158d97583502a7e2739951553cbd88a72076f152b4b11b64b9a10c4c49409",
+                "sha256:732e836008c708de2e89a31cb2fa6c0e5a70cb60492bee6f1ea1047500feaf7f",
+                "sha256:8154ec22c450df4e06b35f131adc4f2f3a12ec85981a203301d310abf580500f",
+                "sha256:8e9d728c4579682e837c92fdd98036bd5cdefa1da2aaf6acf26947e6dd0c01c5",
+                "sha256:d4b3e5329f572f055b587efc57d29bd051589fb5a43ec8898c77a47ec2fa2bbb",
+                "sha256:e5f2585afccbff22390cddac29849df463b252b711aa2ce7c5f3f342a5b3b444"
             ],
             "index": "pypi",
-            "version": "==5.1"
+            "version": "==5.1.1"
         },
         "urllib3": {
             "hashes": [
@@ -225,7 +224,7 @@
                 "sha256:0312ad34fcad8fac3704d441f7b317e50af620823353ec657a53e981f92920c0",
                 "sha256:ec9ae8adaae229e4f8446952d204a3e4b5fdd2d099f9be3aaf556120135fb3ee"
             ],
-            "markers": "python_version != '3.3.*' and python_version != '3.1.*' and python_version != '3.2.*' and python_version != '3.0.*' and python_version >= '2.7'",
+            "markers": "python_version != '3.0.*' and python_version != '3.2.*' and python_version >= '2.7' and python_version != '3.1.*' and python_version != '3.3.*'",
             "version": "==1.2.1"
         },
         "attrs": {
@@ -286,6 +285,14 @@
             ],
             "version": "==0.6.1"
         },
+        "mock": {
+            "hashes": [
+                "sha256:5ce3c71c5545b472da17b72268978914d0252980348636840bd34a00b5cc96c1",
+                "sha256:b158b6df76edd239b8208d481dc46b6afd45a846b7812ff0ce58971cf5bc8bba"
+            ],
+            "index": "pypi",
+            "version": "==2.0.0"
+        },
         "more-itertools": {
             "hashes": [
                 "sha256:c187a73da93e7a8acc0001572aebc7e3c69daf7bf6881a2cea10650bd4420092",
@@ -301,6 +308,13 @@
             ],
             "version": "==0.3.1"
         },
+        "pbr": {
+            "hashes": [
+                "sha256:1b8be50d938c9bb75d0eaf7eda111eec1bf6dc88a62a6412e33bf077457e0f45",
+                "sha256:b486975c0cafb6beeb50ca0e17ba047647f229087bd74e37f4a7e2cac17d2caa"
+            ],
+            "version": "==4.2.0"
+        },
         "pexpect": {
             "hashes": [
                 "sha256:2a8e88259839571d1251d278476f3eec5db26deb73a70be5ed5dc5435e418aba",
@@ -311,17 +325,17 @@
         },
         "pickleshare": {
             "hashes": [
-                "sha256:84a9257227dfdd6fe1b4be1319096c20eb85ff1e82c7932f36efccfe1b09737b",
-                "sha256:c9a2541f25aeabc070f12f452e1f2a8eae2abd51e1cd19e8430402bdf4c1d8b5"
+                "sha256:87683d47965c1da65cdacaf31c8441d12b8044cdec9aca500cd78fc2c683afca",
+                "sha256:9649af414d74d4df115d5d718f82acb59c9d418196b7b4290ed47a12ce62df56"
             ],
-            "version": "==0.7.4"
+            "version": "==0.7.5"
         },
         "pluggy": {
             "hashes": [
                 "sha256:6e3836e39f4d36ae72840833db137f7b7d35105079aee6ec4a62d9f80d594dd1",
                 "sha256:95eb8364a4708392bae89035f45341871286a333f749c3141c20573d2b3876e1"
             ],
-            "markers": "python_version != '3.3.*' and python_version != '3.1.*' and python_version != '3.2.*' and python_version != '3.0.*' and python_version >= '2.7'",
+            "markers": "python_version != '3.0.*' and python_version != '3.2.*' and python_version >= '2.7' and python_version != '3.1.*' and python_version != '3.3.*'",
             "version": "==0.7.1"
         },
         "prompt-toolkit": {
@@ -344,7 +358,7 @@
                 "sha256:06a30435d058473046be836d3fc4f27167fd84c45b99704f2fb5509ef61f9af1",
                 "sha256:50402e9d1c9005d759426988a492e0edaadb7f4e68bcddfea586bc7432d009c6"
             ],
-            "markers": "python_version != '3.3.*' and python_version != '3.1.*' and python_version != '3.2.*' and python_version != '3.0.*' and python_version >= '2.7'",
+            "markers": "python_version != '3.0.*' and python_version != '3.2.*' and python_version >= '2.7' and python_version != '3.1.*' and python_version != '3.3.*'",
             "version": "==1.6.0"
         },
         "pycodestyle": {
@@ -370,11 +384,11 @@
         },
         "pytest": {
             "hashes": [
-                "sha256:453cbbbe5ce6db38717d282b758b917de84802af4288910c12442984bde7b823",
-                "sha256:a8a07f84e680482eb51e244370aaf2caa6301ef265f37c2bdefb3dd3b663f99d"
+                "sha256:0a72d8a9f559c006ba153e0c9b4838efd7b656cf1f993747ba7128770d6eb12c",
+                "sha256:95529588ff4e85114a0b0ad8e9cf0131ca47d46b28230e25366c5aba66b1d854"
             ],
             "index": "pypi",
-            "version": "==3.8.0"
+            "version": "==3.8.1"
         },
         "simplegeneric": {
             "hashes": [

--- a/hbi/client.py
+++ b/hbi/client.py
@@ -55,10 +55,12 @@ class TornadoClient(object):
 
 def run():
     stub = Client()
+    hosts = []
     for name in util.names():
         display_name = "-".join(name)
         facts = {"demo": {"hostname": f"{display_name}"}}
-        stub.create_or_update(Host(display_name=display_name, facts=facts))
+        hosts.append(Host({}, display_name=display_name, facts=facts))
+    stub.create_or_update(hosts)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
[Client](https://github.com/RedHatInsights/host-inventory/blob/667bcd0f9caf5f122c3492fc4b461f3a6c9e573c/hbi/client.py) can’t [run](https://github.com/RedHatInsights/host-inventory/blob/667bcd0f9caf5f122c3492fc4b461f3a6c9e573c/hbi/client.py#L56) because of the following errors:

* [_Host_](https://github.com/RedHatInsights/host-inventory/blob/667bcd0f9caf5f122c3492fc4b461f3a6c9e573c/hbi/model.py#L73) [constructor](https://github.com/RedHatInsights/host-inventory/blob/667bcd0f9caf5f122c3492fc4b461f3a6c9e573c/hbi/model.py#L75) requires a dict of [canonical facts](https://github.com/RedHatInsights/host-inventory/blob/667bcd0f9caf5f122c3492fc4b461f3a6c9e573c/hbi/model.py#L78) as its first positional argument. This [was not given](https://github.com/RedHatInsights/host-inventory/blob/667bcd0f9caf5f122c3492fc4b461f3a6c9e573c/hbi/client.py#L61).
* The [_Client.create_or_update_](https://github.com/RedHatInsights/host-inventory/blob/667bcd0f9caf5f122c3492fc4b461f3a6c9e573c/hbi/client.py#L43) method takes a [list of hosts](https://github.com/RedHatInsights/host-inventory/blob/667bcd0f9caf5f122c3492fc4b461f3a6c9e573c/hbi/client.py#L44). Only one host [was given](https://github.com/RedHatInsights/host-inventory/blob/667bcd0f9caf5f122c3492fc4b461f3a6c9e573c/hbi/client.py#L61).

This fixes allows the client to actually launch without crashing.

I wrote [tests](https://github.com/RedHatInsights/host-inventory/compare/master...Glutexo:fix_client_run?expand=1#diff-df1dec698dcb6806e87b0907c5ccb3e0) for that. I am aware of the [_run_](https://github.com/RedHatInsights/host-inventory/blob/667bcd0f9caf5f122c3492fc4b461f3a6c9e573c/hbi/client.py#L56) method being more of a stub and that the tests may become just an unnecessary burden more than helping ensure that valid data is handed over. If that‘s the case, I can just remove them from the PR.