### PR TITLE
Reduce complexity of hbi.server.Service.get

### DIFF
--- a/hbi/server/__init__.py
+++ b/hbi/server/__init__.py
@@ -43,10 +43,8 @@ class Index(object):
             if h:
                 return h
 
-    def apply_filter(self, f, hosts=None):
-        if hosts is None:
-            hosts = self.all_hosts
-        elif len(hosts) == 0:
+    def apply_filter(self, f, hosts):
+        if not hosts:
             raise StopIteration
 
         # TODO: Actually USE the fact & tag namespaces
@@ -106,15 +104,16 @@ class Service(object):
         return ret
 
     def get(self, filters=None):
-        if not filters:
-            return list(self.index.all_hosts)
-        elif type(filters) != list or any(type(f) != Filter for f in filters):
+        if filters is None:
+            filters = []
+
+        if type(filters) != list or any(type(f) != Filter for f in filters):
             raise ValueError("Query must be a list of Filter objects")
-        else:
-            filtered_set = None
-            for f in filters:
-                filtered_set = set(self.index.apply_filter(f, filtered_set))
-                # If we have no results, we'll never get more so exit now.
-                if len(filtered_set) == 0:
-                    return []
-            return list(filtered_set)
+
+        filtered_set = self.index.all_hosts
+        for f in filters:
+            filtered_set = set(self.index.apply_filter(f, filtered_set))
+            # If we have no results, we'll never get more so exit now.
+            if not filtered_set:
+                break
+        return list(filtered_set)

--- a/hbi/tests.py
+++ b/hbi/tests.py
@@ -1,8 +1,8 @@
 import os
 
-from hbi.server import Host, Filter, Service
+from hbi.server import Host, Filter, Index, Service
 from hbi.util import names
-from pytest import fixture
+from pytest import fixture, mark, raises
 
 MODE = os.environ.get("MODE", "").lower()
 
@@ -34,6 +34,11 @@ def service():
         yield TornadoClient()
     else:
         yield Service()
+
+
+@fixture
+def index():
+    return Index()
 
 
 @fixture
@@ -89,6 +94,19 @@ def test_create_and_get(service, host_list):
 def test_get_one(service, host_list):
     filters = Filter(ids=[service.create_or_update(host_list)[0].id])
     assert len(service.get([filters])) == 1
+
+
+@mark.parametrize(("filters",), [((),),
+                                 ([Filter(), object()],)])
+def test_get_invalid(service, filters):
+    with raises(ValueError):
+        service.get(filters)
+
+
+def test_apply_filter_without_host_list(index):
+    f = Filter(ids=[])
+    with raises(TypeError):
+        index.apply_filter(f)
 
 
 @fixture


### PR DESCRIPTION
Simplified the [_hbi.server.Service.get_](https://github.com/RedHatInsights/host-inventory/blob/667bcd0f9caf5f122c3492fc4b461f3a6c9e573c/hbi/server/__init__.py#L108) method and the closely related
[_hbi.server.Index.apply_filter_](https://github.com/RedHatInsights/host-inventory/blob/667bcd0f9caf5f122c3492fc4b461f3a6c9e573c/hbi/server/__init__.py#L46) method. Made those a bit more DRY and more idiomatic.

* Used [default value](https://github.com/RedHatInsights/host-inventory/compare/master...Glutexo:simplify_server_get?expand=1#diff-8302c941d41073fcb9d1f79a88a27e96R107) for filters instead of a [short circuit](https://github.com/RedHatInsights/host-inventory/compare/master...Glutexo:simplify_server_get?expand=1#diff-8302c941d41073fcb9d1f79a88a27e96L109). This also removed [a behavior](https://github.com/RedHatInsights/host-inventory/pull/8/files#diff-8302c941d41073fcb9d1f79a88a27e96L112) that if the passed _filters_ argument was empty but not a _list_, it was not [validated](https://github.com/RedHatInsights/host-inventory/blob/667bcd0f9caf5f122c3492fc4b461f3a6c9e573c/hbi/server/__init__.py#L111) for being a _list_.
* Removed [an explicit return](https://github.com/RedHatInsights/host-inventory/compare/master...Glutexo:simplify_server_get?expand=1#diff-8302c941d41073fcb9d1f79a88a27e96L119) with [a break](https://github.com/RedHatInsights/host-inventory/compare/master...Glutexo:simplify_server_get?expand=1#diff-8302c941d41073fcb9d1f79a88a27e96R116). `list(empty set)` makes an empty list too, the type coercing now happens in only [one place](https://github.com/RedHatInsights/host-inventory/compare/master...Glutexo:simplify_server_get?expand=1#diff-8302c941d41073fcb9d1f79a88a27e96R117).
* Removed the _apply_filter_ _hosts_ argument [default value](https://github.com/RedHatInsights/host-inventory/compare/master...Glutexo:simplify_server_get?expand=1#diff-8302c941d41073fcb9d1f79a88a27e96L48). The logic is now in only [one place](https://github.com/RedHatInsights/host-inventory/compare/master...Glutexo:simplify_server_get?expand=1#diff-8302c941d41073fcb9d1f79a88a27e96R111) instead of two. This slightly increases the coupling between the [_Index_](https://github.com/RedHatInsights/host-inventory/blob/667bcd0f9caf5f122c3492fc4b461f3a6c9e573c/hbi/server/__init__.py#L13) and the [_Service_](https://github.com/RedHatInsights/host-inventory/blob/667bcd0f9caf5f122c3492fc4b461f3a6c9e573c/hbi/server/__init__.py#L82) class, but they are already coupled and I‘m going to address that in a further PR.
* Used more idiomatic `not iterable` instead of `len(iterable) == 0`. [\[1\]](https://github.com/RedHatInsights/host-inventory/compare/master...Glutexo:simplify_server_get?expand=1#diff-8302c941d41073fcb9d1f79a88a27e96R47) [\[2\]](https://github.com/RedHatInsights/host-inventory/compare/master...Glutexo:simplify_server_get?expand=1#diff-8302c941d41073fcb9d1f79a88a27e96R115)