### PR TITLE
Make in-memory db classes more readable

### DIFF
--- a/hbi/server/__init__.py
+++ b/hbi/server/__init__.py
@@ -6,93 +6,139 @@ from itertools import chain
 from hbi.model import Host, Filter
 
 
-def flat_fact_chain(f):
-    return chain.from_iterable(v.items() for v in f.values())
+def facts_to_lookup_keys(facts):
+    """
+    Converts a dict of facts/tags dicts into a chain of key-value
+    tuples, throwing away the namespaces being the topmost keys.
+    """
+    return chain.from_iterable(v.items() for v in facts.values())
 
 
 class Index(object):
+    """
+    In-memory database-like storage using a native Python dict as a
+    look-up table.
+    """
 
     def __init__(self):
-        self.dict_ = {}
-        self.all_hosts = set()
+        self.all_hosts = set()  # Default unfiltered result set
+
+        # Look-up tables
+        self.dict = {}
         self.account_dict = defaultdict(set)
 
     def add(self, host):
+        """
+        Add a new host to the database.
+        """
         if not isinstance(host, Host):
             msg = f"Index only stores Host objects, was given type {type(host)}"
             raise ValueError(msg)
+
         self.all_hosts.add(host)
-        self.dict_[host.id] = host
+
+        # Look-ups that return a single host
+        self.dict[host.id] = host
         self.account_dict[host.account_number].add(host)
         for t in host.canonical_facts.items():
-            self.dict_[t] = host
+            self.dict[t] = host
+
+        # Look-ups that return multiple hosts
         # TODO: Actually USE the namespaces
-        f_chain = flat_fact_chain(host.facts)
-        t_chain = flat_fact_chain(host.tags)
-        for t in chain(f_chain, t_chain):
-            if t not in self.dict_:
-                self.dict_[t] = set()
-            self.dict_[t].add(host)
+        facts_keys = facts_to_lookup_keys(host.facts)
+        tags_keys = facts_to_lookup_keys(host.tags)
+        for t in chain(facts_keys, tags_keys):
+            if t not in self.dict:
+                self.dict[t] = set()
+            self.dict[t].add(host)
 
     def get(self, host):
+        """
+        Get a host by its id or any canonical fact.
+        """
         if host.id:
-            return self.dict_.get(host.id)
+            return self.dict.get(host.id)
 
-        for t in host.canonical_facts.items():
-            h = self.dict_.get(t)
+        for lookup_key in host.canonical_facts.items():
+            h = self.dict.get(lookup_key)
             if h:
                 return h
 
     def apply_filter(self, f, hosts=None):
+        """
+        Filter given (or all) hosts.
+        """
+
         if hosts is None:
             hosts = self.all_hosts
         elif len(hosts) == 0:
             raise StopIteration
 
         # TODO: Actually USE the fact & tag namespaces
-        iterables = filter(None, (
+        lookup_keys_iterables = filter(None, (
             f.ids, f.canonical_facts.items(),
-            flat_fact_chain(f.facts),
-            flat_fact_chain(f.tags)
+            facts_to_lookup_keys(f.facts),
+            facts_to_lookup_keys(f.tags)
         ))
 
         if f.account_numbers:
             for acct in f.account_numbers:
                 yield from self.account_dict[acct]
 
-        for i in chain(*iterables):
-            v = self.dict_.get(i)
+        for lookup_key in chain(*lookup_keys_iterables):
+            v = self.dict.get(lookup_key)
             if type(v) == set:
-                yield from (i for i in v if i in hosts)
+                yield from (host for host in v if host in hosts)
             elif v in hosts:
                 yield v
 
     # orig *has* to be from a `get` to be safe
-    def merge(self, orig, new):
-        for t in orig.canonical_facts.items():
-            del self.dict_[t]
+    def merge(self, existing_host, new_host):
+        """
+        Merge data from a new host to an existing host.
+        """
+        # Delete all original canonical facts lookup keys, so the host
+        # can be found only with the new ones.
+        for lookup_key in existing_host.canonical_facts.items():
+            del self.dict[lookup_key]
 
         # TODO: update index dict for facts and tags
-        orig.merge(new)
+        existing_host.merge(new_host)
 
-        for t in orig.canonical_facts.items():
-            self.dict_[t] = orig
+        for lookup_key in existing_host.canonical_facts.items():
+            self.dict[lookup_key] = existing_host
 
 
 class Service(object):
+    """
+    An interface for the host database.
+    """
+
     def __init__(self):
+        """
+        Creates a new in-memory database. (Like setting up a new RDBMS
+        connection.)
+        """
         self.index = Index()
 
     def reset(self):
+        """
+        Throw away the current in-memory database and create a new one.
+        (Like rolling back pending RDBMS transactions.)
+        """
         self.index = Index()
 
     def create_or_update(self, hosts):
+        """
+        Saves a new host data to the database: either creates a new host
+        or updates an existing one.
+        """
         ret = []
         for h in hosts:
             if h.canonical_facts is None and h.id is None:
                 raise ValueError("Must provide at least one canonical fact or the ID")
 
-            # search the canonical_facts dict for a match
+            # Search the look-up table for a match
             existing_host = self.index.get(h)
             if existing_host:
                 self.index.merge(existing_host, h)
@@ -106,6 +152,10 @@ class Service(object):
         return ret
 
     def get(self, filters=None):
+        """
+        Gets all hosts that match given filters. All hosts if no filters
+        are given.
+        """
         if not filters:
             return list(self.index.all_hosts)
         elif type(filters) != list or any(type(f) != Filter for f in filters):


### PR DESCRIPTION
I tried to make the current state of the [_Index_](https://github.com/RedHatInsights/host-inventory/blob/667bcd0f9caf5f122c3492fc4b461f3a6c9e573c/hbi/server/__init__.py#L13) and [_Service_](https://github.com/RedHatInsights/host-inventory/blob/667bcd0f9caf5f122c3492fc4b461f3a6c9e573c/hbi/server/__init__.py#L82) classes a little more understandable without writing too much comments. I fought with them a bit before I understood what it does, even though it’s quite simple.

* Added brief comments to the two classes and to all methods. Added a few line comments.
* Renamed a few variables and methods to be more semantic. Removed the _chain_ technical term,  focused on the idea of _look-up_ table and keys.
* Renamed [_dict__](https://github.com/RedHatInsights/host-inventory/compare/master...Glutexo:server_init_readability?expand=1#diff-8302c941d41073fcb9d1f79a88a27e96L16) to [_dict_](https://github.com/RedHatInsights/host-inventory/compare/master...Glutexo:server_init_readability?expand=1#diff-8302c941d41073fcb9d1f79a88a27e96R27). Since it’s a property, it does not shadow the built-in class name. But I don’t insist on this change.

I was tempted to rename the [_dict__](https://github.com/RedHatInsights/host-inventory/blob/667bcd0f9caf5f122c3492fc4b461f3a6c9e573c/hbi/server/__init__.py#L16) and [_account_dict_](https://github.com/RedHatInsights/host-inventory/blob/667bcd0f9caf5f122c3492fc4b461f3a6c9e573c/hbi/server/__init__.py#L18) to something more _look-up-tabley_. I resisted, because _dict_ is nicely concise.

I understand that changes like this are mostly a matter of personal preference, so I tried not to make too much and honor your style @kylape. My goal was to make some pieces more descriptive and lower the entry barrier.