### PR TITLE
Remove type validation

### DIFF
--- a/hbi/server/__init__.py
+++ b/hbi/server/__init__.py
@@ -18,9 +18,6 @@ class Index(object):
         self.account_dict = defaultdict(set)
 
     def add(self, host):
-        if not isinstance(host, Host):
-            msg = f"Index only stores Host objects, was given type {type(host)}"
-            raise ValueError(msg)
         self.all_hosts.add(host)
         self.dict_[host.id] = host
         self.account_dict[host.account_number].add(host)
@@ -108,8 +105,6 @@ class Service(object):
     def get(self, filters=None):
         if not filters:
             return list(self.index.all_hosts)
-        elif type(filters) != list or any(type(f) != Filter for f in filters):
-            raise ValueError("Query must be a list of Filter objects")
         else:
             filtered_set = None
             for f in filters:


### PR DESCRIPTION
Removed unnecessary type validations from the server storage driver.

I think that it’s not necessary to verify the types. It’s not a public API, so it’s just our developers’ responsibility to pass an argument of the right type. Python’s very ducky, so as long as the object has the necessary interface, it’s fine.

If you don’t agree with removing the [_Host_](https://github.com/RedHatInsights/host-inventory/compare/master...Glutexo:remove_type_validations?expand=1#diff-8302c941d41073fcb9d1f79a88a27e96L21) and [_Filter_](https://github.com/RedHatInsights/host-inventory/compare/master...Glutexo:remove_type_validations?expand=1#diff-8302c941d41073fcb9d1f79a88a27e96L111) validations, then I’d at least not [_test_](https://github.com/RedHatInsights/host-inventory/blob/667bcd0f9caf5f122c3492fc4b461f3a6c9e573c/hbi/server/__init__.py#L111) if the [filter list](https://github.com/RedHatInsights/host-inventory/blob/667bcd0f9caf5f122c3492fc4b461f3a6c9e573c/hbi/server/__init__.py#L108) is a real _list_.