### PR TITLE
Do not coerce hosts to lists

### DIFF
--- a/hbi/server/__init__.py
+++ b/hbi/server/__init__.py
@@ -107,7 +107,7 @@ class Service(object):
 
     def get(self, filters=None):
         if not filters:
-            return list(self.index.all_hosts)
+            return self.index.all_hosts
         elif type(filters) != list or any(type(f) != Filter for f in filters):
             raise ValueError("Query must be a list of Filter objects")
         else:
@@ -116,5 +116,5 @@ class Service(object):
                 filtered_set = set(self.index.apply_filter(f, filtered_set))
                 # If we have no results, we'll never get more so exit now.
                 if len(filtered_set) == 0:
-                    return []
-            return list(filtered_set)
+                    return set()
+            return filtered_set


### PR DESCRIPTION
Removed unnecessary coercing hosts from set to list.

The result of the [_Service.get_](https://github.com/RedHatInsights/host-inventory/blob/667bcd0f9caf5f122c3492fc4b461f3a6c9e573c/hbi/server/__init__.py#L108) method is only used for iteration. [\[1\]](https://github.com/RedHatInsights/host-inventory/blob/667bcd0f9caf5f122c3492fc4b461f3a6c9e573c/hbi/server/grpc_server.py#L25) [\[2\]](https://github.com/RedHatInsights/host-inventory/blob/667bcd0f9caf5f122c3492fc4b461f3a6c9e573c/hbi/server/tornado_server.py#L31) Thus there is no need for it to be exactly _list_, especially when it’s always converted from a _set_. Any iterable is just fine, so it can be directly the _set_. If there were a case where _list_ and only _list_ would be necessary, it’s always possible to build it with `list(service.get())`.