### PR TITLE
Optimize filtering

### DIFF
--- a/hbi/model.py
+++ b/hbi/model.py
@@ -25,11 +25,11 @@ class Filter(object):
 
     def __init__(self, canonical_facts=None, ids=None, account_numbers=None,
                  tags=None, facts=None):
-        self.ids = ids
+        self.ids = ids or set()
         self.canonical_facts = canonical_facts or {}
         self.tags = tags or defaultdict(dict)
         self.facts = facts or defaultdict(dict)
-        self.account_numbers = account_numbers
+        self.account_numbers = account_numbers or set()
 
     @classmethod
     def from_pb(cls, filter_):

--- a/hbi/server/__init__.py
+++ b/hbi/server/__init__.py
@@ -49,18 +49,18 @@ class Index(object):
         elif len(hosts) == 0:
             raise StopIteration
 
-        # TODO: Actually USE the fact & tag namespaces
-        iterables = filter(None, (
-            f.ids, f.canonical_facts.items(),
-            flat_fact_chain(f.facts),
-            flat_fact_chain(f.tags)
-        ))
-
         if f.account_numbers:
             for acct in f.account_numbers:
                 yield from self.account_dict[acct]
 
-        for i in chain(*iterables):
+        # TODO: Actually USE the fact & tag namespaces
+        queries = chain(
+            f.ids,
+            f.canonical_facts.items(),
+            flat_fact_chain(f.facts),
+            flat_fact_chain(f.tags)
+        )
+        for i in queries:
             v = self.dict_.get(i)
             if type(v) == set:
                 yield from (i for i in v if i in hosts)


### PR DESCRIPTION
Extended default filter values to [_ids_](https://github.com/RedHatInsights/host-inventory/compare/master...Glutexo:optimize_apply_filter?expand=1#diff-87bb162c832e21c37ba5348e6013897bR28) and [_account_numbers_](https://github.com/RedHatInsights/host-inventory/compare/master...Glutexo:optimize_apply_filter?expand=1#diff-87bb162c832e21c37ba5348e6013897bR32). That allows to skip [_filter_](https://github.com/RedHatInsights/host-inventory/compare/master...Glutexo:optimize_apply_filter?expand=1#diff-8302c941d41073fcb9d1f79a88a27e96L53) before [chaining](https://github.com/RedHatInsights/host-inventory/compare/master...Glutexo:optimize_apply_filter?expand=1#diff-8302c941d41073fcb9d1f79a88a27e96L63) the conditions in the [_apply_filter_](https://github.com/RedHatInsights/host-inventory/blob/667bcd0f9caf5f122c3492fc4b461f3a6c9e573c/hbi/server/__init__.py#L46) method. Empty sets just go through [the iteration](https://github.com/RedHatInsights/host-inventory/blob/667bcd0f9caf5f122c3492fc4b461f3a6c9e573c/hbi/server/__init__.py#L63) not yielding anything. Moved the [chaining](https://github.com/RedHatInsights/host-inventory/compare/master...Glutexo:optimize_apply_filter?expand=1#diff-8302c941d41073fcb9d1f79a88a27e96R57) closer to the iteration.