### PR TITLE
Fix apply_filter on empty set

### DIFF
--- a/hbi/server/__init__.py
+++ b/hbi/server/__init__.py
@@ -47,7 +47,7 @@ class Index(object):
         if hosts is None:
             hosts = self.all_hosts
         elif len(hosts) == 0:
-            raise StopIteration
+            return
 
         # TODO: Actually USE the fact & tag namespaces
         iterables = filter(None, (

--- a/hbi/tests.py
+++ b/hbi/tests.py
@@ -1,6 +1,6 @@
 import os
 
-from hbi.server import Host, Filter, Service
+from hbi.server import Host, Index, Filter, Service
 from hbi.util import names
 from pytest import fixture
 
@@ -34,6 +34,11 @@ def service():
         yield TornadoClient()
     else:
         yield Service()
+
+
+@fixture
+def index():
+    return Index()
 
 
 @fixture
@@ -275,3 +280,9 @@ def test_get_tag(service):
     service.create_or_update([h])
     r = service.get([Filter(tags=tags)])
     assert len(r) == 1
+
+
+def test_index_apply_filter_to_no_hosts(index):
+    hosts = set()
+    hosts = index.apply_filter(Filter(), hosts)
+    assert not set(hosts)


### PR DESCRIPTION
The [_Index.apply_filter_](https://github.com/RedHatInsights/host-inventory/blob/667bcd0f9caf5f122c3492fc4b461f3a6c9e573c/hbi/server/__init__.py#L46) method used [`raise StopIteration`](https://github.com/RedHatInsights/host-inventory/compare/master...Glutexo:fix_apply_filter_iteration?expand=1#diff-8302c941d41073fcb9d1f79a88a27e96L50) to indicate that the host list is depleted. This usage is deprecated by [PEP 479](https://www.python.org/dev/peps/pep-0479/) and explicitly raising _StopIteration_ translates to _RuntimeError_. Bare return is the way how to do it.